### PR TITLE
SDK 2.47.0

### DIFF
--- a/_mvDeviceManager.pxd
+++ b/_mvDeviceManager.pxd
@@ -125,8 +125,8 @@ cdef extern from "mvDeviceManager/Include/mvDeviceManager.h":
         dmltRTCtr
         dmltCameraDescriptions
         dmltDeviceSpecificData
-        dmltEventSubSystemSettings
-        dmltEventSubSystemResults
+        #dmltEventSubSystemSettings
+        #dmltEventSubSystemResults
         dmltImageMemoryManager
 
     ctypedef TOBJ_HandleCheckMode TOBJ_HandleCheckMode

--- a/_mvDeviceManager.pyx
+++ b/_mvDeviceManager.pyx
@@ -448,8 +448,8 @@ cdef dict lists = {
     'Real_time_control': dmltRTCtr,
     'Camera_descriptions': dmltCameraDescriptions,
     'Device_specific_data': dmltDeviceSpecificData,
-    'Event_sub_system': dmltEventSubSystemSettings,
-    'Event_sub_system_results': dmltEventSubSystemResults,
+   # 'Event_sub_system': dmltEventSubSystemSettings,
+   # 'Event_sub_system_results': dmltEventSubSystemResults,
     'Image_memory_manager': dmltImageMemoryManager,
     }
        

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ if system == 'Windows' and bits == '64bit':
     mvlib = os.path.join(mvlib, r'win\x64')
 elif system == 'Linux' and bits == '64bit' and machine == 'aarch64':
     mvlib = os.path.join(mvlib, 'arm64')
+elif system == 'Linux' and bits == '32bit' and machine == 'armv7l':
+    mvlib = os.path.join(mvlib, 'arm')
 elif system == 'Linux' and bits == '64bit' and machine == 'x86_64':
     mvlib = os.path.join(mvlib, 'x86_64')
 else:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if system == 'Windows' and bits == '64bit':
 elif system == 'Linux' and bits == '64bit' and machine == 'aarch64':
     mvlib = os.path.join(mvlib, 'arm64')
 elif system == 'Linux' and bits == '32bit' and machine == 'armv7l':
-    mvlib = os.path.join(mvlib, 'arm')
+    mvlib = os.path.join(mvlib, 'armv7l')
 elif system == 'Linux' and bits == '64bit' and machine == 'x86_64':
     mvlib = os.path.join(mvlib, 'x86_64')
 else:


### PR DESCRIPTION
Hello!
I've made some changes to compile using latest version of MatrixVision SDK 2.47.0. 
In the SDK 2.47.0 dmltEventSubSystemSettings and dmltEventSubSystemResults were removed.
I also added the support to compile in armv7l architecture. (mvBlueFOX-ARMhf_gnueabi-2.47.0.tgz)

Andrea